### PR TITLE
更新.gitignore以排除更多IDE和操作系统生成的文件，更新mod版本至1.3.5，重构APull命令以支持系统收购功能，修复多个视…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,85 @@
-# 项目排除路径
-/.gradle/
-/build/
-/build/classes/kotlin/client/
-/build/classes/kotlin/main/
+# Gradle
+.gradle/
+build/
+!build/resources/
+.gradletasknamecache
+
+# IDE - IntelliJ IDEA
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+
+# IDE - Eclipse
+.classpath
+.project
+.settings/
+bin/
+
+# IDE - VS Code
+.vscode/
+*.code-workspace
+
+# IDE - NetBeans
+nbproject/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+
+# Operating System
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+desktop.ini
+
+# Runtime files (Minecraft server)
+run/
+identifier.sqlite
+*.db
+*.sqlite
+*.sqlite3
+
+# Logs
+*.log
+*.log.*
+logs/
+*.gz
+
+# Backup files
+*.backup
+*.bak
+*~
+*.swp
+*.swo
+
+# Temporary files
+*.tmp
+*.temp
+*.cache
+tmp/
+temp/
+
+# Compiled class files
+*.class
+
+# Package Files
+*.jar
+!gradle/wrapper/gradle-wrapper.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# Virtual machine crash logs
+hs_err_pid*
+
+# Kotlin
+*.kotlin_module

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ loader_version=0.17.2
 kotlin_loader_version=1.13.5+kotlin.2.2.10
 
 # Mod Properties
-mod_version = 1.3.4
+mod_version = 1.3.5
 maven_group = asagiribeta
 archives_base_name = Server-market
 

--- a/src/main/kotlin/asagiribeta/serverMarket/menu/view/MyPurchaseView.kt
+++ b/src/main/kotlin/asagiribeta/serverMarket/menu/view/MyPurchaseView.kt
@@ -74,7 +74,7 @@ class MyPurchaseView(private val gui: MarketGui) {
         } else 0
 
         val element = GuiElementBuilder.from(stack)
-            .setName(Text.literal(entry.itemId))
+            .setName(stack.getName())
             .addLoreLine(Text.literal(Language.get("ui.price", String.format(Locale.ROOT, "%.2f", entry.price))))
             .addLoreLine(Text.literal(Language.get("menu.mypurchase.progress",
                 entry.currentAmount, entry.targetAmount, progressPercent)))
@@ -133,22 +133,22 @@ class MyPurchaseView(private val gui: MarketGui) {
             .addLoreLine(Text.literal(Language.get("menu.mypurchase.count", myPurchases.size)))
         gui.setSlot(46, helpItem)
 
-        // 下一页
-        setNavButton(47, Items.ARROW, Language.get("menu.next", "${gui.page + 1}/$totalPages")) {
-            if (gui.page < totalPages - 1) {
-                gui.page++
-                show(false)
-            }
-        }
-
         // 返回首页
-        setNavButton(49, Items.NETHER_STAR, Language.get("menu.back_home")) {
+        setNavButton(47, Items.NETHER_STAR, Language.get("menu.back_home")) {
             gui.showHome()
         }
 
         // 关闭
-        setNavButton(53, Items.BARRIER, Language.get("menu.close")) {
+        setNavButton(49, Items.BARRIER, Language.get("menu.close")) {
             gui.close()
+        }
+
+        // 下一页
+        setNavButton(53, Items.ARROW, Language.get("menu.next", "${gui.page + 1}/$totalPages")) {
+            if (gui.page < totalPages - 1) {
+                gui.page++
+                show(false)
+            }
         }
     }
 

--- a/src/main/kotlin/asagiribeta/serverMarket/menu/view/MyShopDetailView.kt
+++ b/src/main/kotlin/asagiribeta/serverMarket/menu/view/MyShopDetailView.kt
@@ -43,7 +43,7 @@ class MyShopDetailView(private val gui: MarketGui) {
 
         // 中央展示物品（槽位 22）
         val displayItem = GuiElementBuilder.from(stack)
-            .setName(Text.literal("§e${item.itemId}"))
+            .setName(Text.literal(stack.getName().string).styled { it.withColor(0xFFFF00) })
             .addLoreLine(Text.literal(""))
             .addLoreLine(Text.literal(Language.get("ui.price", String.format(Locale.ROOT, "%.2f", item.price))))
             .addLoreLine(Text.literal(Language.get("ui.quantity", item.quantity)))

--- a/src/main/kotlin/asagiribeta/serverMarket/menu/view/MyShopView.kt
+++ b/src/main/kotlin/asagiribeta/serverMarket/menu/view/MyShopView.kt
@@ -69,7 +69,7 @@ class MyShopView(private val gui: MarketGui) {
         }
 
         val element = GuiElementBuilder.from(stack)
-            .setName(Text.literal(item.itemId))
+            .setName(stack.getName())
             .addLoreLine(Text.literal(Language.get("ui.price", String.format(Locale.ROOT, "%.2f", item.price))))
             .addLoreLine(Text.literal(Language.get("ui.quantity", item.quantity)))
             .addLoreLine(Text.literal(""))
@@ -101,22 +101,22 @@ class MyShopView(private val gui: MarketGui) {
             .addLoreLine(Text.literal(Language.get("menu.myshop.count", myItems.size)))
         gui.setSlot(46, helpItem)
 
-        // 下一页
-        setNavButton(47, Items.ARROW, Language.get("menu.next", "${gui.page + 1}/$totalPages")) {
-            if (gui.page < totalPages - 1) {
-                gui.page++
-                show(false)
-            }
-        }
-
         // 返回首页
-        setNavButton(49, Items.NETHER_STAR, Language.get("menu.back_home")) {
+        setNavButton(47, Items.NETHER_STAR, Language.get("menu.back_home")) {
             gui.showHome()
         }
 
         // 关闭
-        setNavButton(53, Items.BARRIER, Language.get("menu.close")) {
+        setNavButton(49, Items.BARRIER, Language.get("menu.close")) {
             gui.close()
+        }
+
+        // 下一页
+        setNavButton(53, Items.ARROW, Language.get("menu.next", "${gui.page + 1}/$totalPages")) {
+            if (gui.page < totalPages - 1) {
+                gui.page++
+                show(false)
+            }
         }
     }
 

--- a/src/main/kotlin/asagiribeta/serverMarket/menu/view/ParcelStationView.kt
+++ b/src/main/kotlin/asagiribeta/serverMarket/menu/view/ParcelStationView.kt
@@ -77,7 +77,7 @@ class ParcelStationView(private val gui: MarketGui) {
         val timeStr = SimpleDateFormat("yyyy-MM-dd HH:mm").format(Date(entry.timestamp))
 
         val element = GuiElementBuilder.from(stack)
-            .setName(Text.literal(entry.itemId))
+            .setName(stack.getName())
             .addLoreLine(Text.literal(Language.get("menu.parcel.reason", entry.reason)))
             .addLoreLine(Text.literal(Language.get("menu.parcel.time", timeStr)))
             .addLoreLine(Text.literal(Language.get("ui.quantity", entry.quantity)))

--- a/src/main/kotlin/asagiribeta/serverMarket/menu/view/PurchaseListView.kt
+++ b/src/main/kotlin/asagiribeta/serverMarket/menu/view/PurchaseListView.kt
@@ -112,7 +112,7 @@ class PurchaseListView(private val gui: MarketGui) {
         } else "∞"
 
         val element = GuiElementBuilder.from(stack)
-            .setName(Text.literal(entry.itemId))
+            .setName(stack.getName())
             .addLoreLine(Text.literal(Language.get("menu.purchase.buyer", entry.buyerName)))
             .addLoreLine(Text.literal(Language.get("menu.purchase.price", String.format(Locale.ROOT, "%.2f", entry.price))))
             .addLoreLine(Text.literal(Language.get("menu.purchase.limit", if (entry.buyerName == "SERVER") limitStr else remainingStr)))

--- a/src/main/kotlin/asagiribeta/serverMarket/menu/view/SellerShopView.kt
+++ b/src/main/kotlin/asagiribeta/serverMarket/menu/view/SellerShopView.kt
@@ -73,7 +73,7 @@ class SellerShopView(private val gui: MarketGui) {
         val stockStr = if (entry.isSystem && entry.quantity < 0) "∞" else entry.quantity.toString()
 
         val element = GuiElementBuilder.from(stack)
-            .setName(Text.literal(entry.itemId))
+            .setName(stack.getName())
             .addLoreLine(Text.literal(Language.get("ui.seller", entry.sellerName)))
             .addLoreLine(Text.literal(Language.get("ui.price", String.format(Locale.ROOT, "%.2f", entry.price))))
             .addLoreLine(Text.literal(Language.get("ui.quantity", stockStr)))


### PR DESCRIPTION
…图中的物品名称显示，优化ItemKey的NBT缓存逻辑。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches command behavior and item identity/caching (`ItemKey.snbtOf`), which can affect market/purchase matching and persistence; UI changes are low risk but should be sanity-checked for regressions in listing/unlisting and item comparisons.
> 
> **Overview**
> **Admin command update:** `APull` now defaults to unlisting system *sale* items and adds `/svm edit pull purchase` to unlist system *purchase* orders, using the held item’s `itemId` + normalized SNBT for lookup/removal.
> 
> **UI fixes:** Multiple market/parcel/purchase views now display item names from the rendered `ItemStack` instead of raw `itemId`, and some navigation buttons are repositioned to new slots.
> 
> **Stability/packaging:** `ItemKey.snbtOf` switches its LRU cache key from `components.hashCode()` to the full normalized SNBT string to avoid hash collisions causing incorrect item icons; `mod_version` bumps to `1.3.5`, and `.gitignore` is expanded for Gradle/IDEs/OS/runtime/log/temp artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9286ceb208f2b36e58bb5d47ec711379e9b353b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->