### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single product: **Server Market**, a server-side **Minecraft 1.21.10 Fabric mod** written in Kotlin and built with Gradle (Kotlin DSL) via the `./gradlew` wrapper. There is no JS/Python toolchain, no `Makefile`, and no automated test source set (`:test` is `NO-SOURCE`).
+
+### Prerequisites (already provided by the environment)
+- JDK 21 (the Gradle Java toolchain targets Java 21).
+- Gradle is provided by the wrapper (`./gradlew`, pinned to 9.2.0). Do not install Gradle globally.
+- First `build`/`runServer`/`runClient` downloads Minecraft, Yarn mappings, and Maven deps from the network; these are cached in `~/.gradle` and the Loom cache, so subsequent runs are fast.
+
+### Build / compile (this is the "lint")
+- Build the mod jar: `./gradlew build` → outputs `build/libs/Server-market_1.21.10-<version>.jar`.
+- There is no separate linter; the meaningful static check is `:compileKotlin`, which runs as part of `build`.
+- The warning `(3.45.1.0) is not valid semver for dependency org.xerial:sqlite-jdbc` during `:processIncludeJars` is benign.
+
+### Run the dev server (primary way to test end-to-end)
+- Run: `./gradlew runServer`. This launches a dedicated Minecraft server (the mod's `environment` is `server`) on port **25565** with the run directory at `run/` (gitignored).
+- First run stops immediately with "You need to agree to the EULA". To proceed you must set `eula=true` in `run/eula.txt`, then re-run. This is a one-time gotcha per fresh `run/` dir.
+- To allow the dev client (or any offline client) to connect without Mojang auth, set `online-mode=false` and `enforce-secure-profile=false` in `run/server.properties`.
+- The server console is interactive: you can type mod commands directly (without a leading `/`), e.g. `svm admin set <player> <amount>` and `svm admin balance <player>`. The console has op level 4, so admin commands work from it.
+- Storage defaults to embedded **SQLite** (`run/market.db`); no external DB is required. MySQL is optional (`storage_type=mysql` + `mysql_*` in `config/server-market/config.properties`).
+
+### Run the dev client (optional, for in-game / GUI testing)
+- Run: `DISPLAY=:1 ./gradlew runClient` (a display server is available at `:1`). Audio/OpenAL errors in the log are expected (no sound card) and are non-fatal.
+- The dev client auto-generates a player username like `Player###` (visible in the server log on join). Use that name for admin commands such as `svm admin set <name> <amount>`.
+- In-game, open chat with `t`, then run e.g. `/svm money` (shows balance) or `/svm menu` (opens the Server Market GUI). `/svm admin set` requires the target player to be online.
+
+### Notes
+- `fabric-permissions-api` is a hard dependency but is pulled by Gradle for the dev runtime; on a real server it must be installed separately. LuckPerms / XConomy are optional.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for the **Server Market** Fabric Minecraft mod so future Cloud Agents can build, run, and test it.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering build/compile (the de-facto lint), running the dev server (`runServer`) with the EULA/offline-mode gotchas, running the dev client (`runClient`) on display `:1`, and SQLite-by-default storage.
- Registers a minimal, idempotent update script (`./gradlew dependencies --configuration runtimeClasspath -q`) to refresh dependencies on VM startup. No code changes to the mod.

## Verification

- `./gradlew build` → `BUILD SUCCESSFUL`, produced `Server-market_1.21.10-2.1.2.jar` (`:compileKotlin` ran as the static check; `:test` is `NO-SOURCE`).
- `./gradlew runServer` → server up on port 25565, mod loaded, SQLite initialized.
- Console economy: `svm admin set Player707 1000` → `Set Player707's balance to 1,000.00`; `svm admin balance Player707` → `balance: 1,000.00`.
- In-game via `runClient`: `/svm money` showed `Your current balance: 1,000.00`; `/svm menu` opened the Server Market GUI.

[server_market_economy_demo.mp4](https://cursor.com/agents/bc-27acb877-3d5f-44c8-ba11-50215f57f612/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fserver_market_economy_demo.mp4)

[svm money balance](https://cursor.com/agents/bc-27acb877-3d5f-44c8-ba11-50215f57f612/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsvm_money_balance.webp)
[Server Market GUI](https://cursor.com/agents/bc-27acb877-3d5f-44c8-ba11-50215f57f612/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsvm_market_gui.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27acb877-3d5f-44c8-ba11-50215f57f612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27acb877-3d5f-44c8-ba11-50215f57f612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

