### PR TITLE
docs: Wiki-ready documentation and CI skip for Markdown-only pushes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -2,55 +2,38 @@
 
 [中文说明](./README_ZH.md)
 
-Currency and market mod for Minecraft Fabric servers (GUI + commands).
+**Server Market** is a Fabric server-side mod that adds a player economy and trading marketplace (GUI + commands).
+
+## Features
+
+- Player balances, transfers, and transaction history
+- Player shops and system store
+- Buy orders, parcel station delivery, optional physical currency
+- SQLite by default; optional MySQL / XConomy record integration
+- Inter-mod API (`ServerMarketApi`, `EconomyProvider`) and market events
 
 ## Supported versions
 
-Run `./gradlew buildAll` on `master` to produce **6 JARs** covering **Minecraft 1.20 – 1.21.11**:
+Minecraft **1.20 – 1.21.11** (Fabric). Pick the JAR that matches your server version from [Releases](https://github.com/AsagiriBeta/Server-market/releases).
 
-| Artifact suffix | Minecraft range |
-|---|---|
-| `Server-market_1_20_4-*.jar` | 1.20 – 1.20.4 |
-| `Server-market_1_20_6-*.jar` | 1.20.5 – 1.20.6 |
-| `Server-market_1_21_1-*.jar` | 1.21 – 1.21.1 |
-| `Server-market_1_21_5-*.jar` | 1.21.2 – 1.21.5 |
-| `Server-market_1_21_8-*.jar` | 1.21.6 – 1.21.8 |
-| `Server-market_1_21_11-*.jar` | 1.21.9 – 1.21.11 |
+## Documentation
 
-Build everything:
+Detailed docs live in the repo (also suitable as GitHub Wiki pages):
 
-```bash
-./gradlew buildAll
-```
+| Page | Description |
+|------|-------------|
+| [Installation](./docs/Installation.md) | Dependencies, setup, configuration |
+| [Commands](./docs/Commands.md) | Full `/svm` command reference |
+| [Dev](./docs/Dev.md) | Building from source, project layout, API |
 
-Build one group:
+## Quick start
 
 ```bash
-./gradlew build -Pmc_group=1_21_11
+/svm              # open market GUI
+/svm money        # check balance
+/svm pay <player> <amount>
 ```
 
-## Admin balance commands
+## License
 
-```bash
-/svm admin add <player> <amount>      # add balance
-/svm admin remove <player> <amount>     # deduct balance
-/svm admin set <player> <amount>      # set balance
-/svm admin balance <player>             # query balance (offline OK)
-```
-
-## Source layout
-
-```
-src/
-  common/       # shared logic
-  versions/
-    v1_20_4/    # legacy NBT ItemKey / GUI (1.20 – 1.20.4)
-    v1_20_6/    # legacy-compatible ItemKey / GUI helpers
-    v1_21_11/   # 1.21.9+ Placeholder API + modern ItemKey
-```
-
-## CI
-
-GitHub Actions runs `buildAll` and publishes release assets **only on pushes to `master`**.
-
-See [README_ZH.md](./README_ZH.md) for the full feature list and Chinese documentation.
+See [LICENSE.txt](./LICENSE.txt).

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -2,162 +2,38 @@
 
 [English](./README.md)
 
-为 Minecraft 服务器提供玩家经济 + 交易市场（GUI + 命令）。
+**Server Market** 是一款 Fabric 服务端模组，提供玩家经济与交易市场（GUI + 命令）。
 
-## 版本 / 依赖
+## 功能概览
 
-### 支持的 Minecraft 版本
+- 玩家余额、转账与交易历史
+- 玩家商店与系统商店
+- 收购订单、快递驿站投递、可选实物货币
+- 默认 SQLite；可选 MySQL / XConomy 记录写入
+- 模组联动 API（`ServerMarketApi`、`EconomyProvider`）与市场事件
 
-主支 `master` 一次 `./gradlew buildAll` 可构建 **6 个 JAR**，覆盖 **1.20 – 1.21.11**：
+## 支持版本
 
-| JAR 文件名后缀 | 兼容版本 |
-|---|---|
-| `Server-market_1_20_4-*.jar` | 1.20 – 1.20.4 |
-| `Server-market_1_20_6-*.jar` | 1.20.5 – 1.20.6 |
-| `Server-market_1_21_1-*.jar` | 1.21 – 1.21.1 |
-| `Server-market_1_21_5-*.jar` | 1.21.2 – 1.21.5 |
-| `Server-market_1_21_8-*.jar` | 1.21.6 – 1.21.8 |
-| `Server-market_1_21_11-*.jar` | 1.21.9 – 1.21.11 |
+Minecraft **1.20 – 1.21.11**（Fabric）。请从 [Releases](https://github.com/AsagiriBeta/Server-market/releases) 下载与服务器版本匹配的 JAR。
 
-> 1.20 – 1.20.4 使用独立 overlay（纯 NBT API，Java 17 字节码）；1.20.5+ 使用组件 API overlay。
+## 文档
 
-### 构建
+详细说明见仓库内文档（可直接用作 GitHub Wiki 页面）：
+
+| 页面 | 说明 |
+|------|------|
+| [Installation](./docs/Installation.md) | 依赖、安装与配置 |
+| [Commands](./docs/Commands.md) | `/svm` 命令完整参考 |
+| [Dev](./docs/Dev.md) | 源码构建、项目结构与 API |
+
+## 快速上手
 
 ```bash
-# 构建全部版本
-./gradlew buildAll
-
-# 构建单个版本组
-./gradlew build -Pmc_group=1_21_11
-```
-
-### 运行时依赖
-
-必需：
-- Fabric Permissions API（版本随 MC 版本变化，见 `gradle.properties`）
-- Fabric Language Kotlin
-
-可选：
-- LuckPerms（推荐）用于权限管理
-
-## 功能
-
-- 玩家余额（转账/交易）
-- 玩家市场 + 系统商店
-- 收购订单（玩家/管理员）+ 快递驿站自动投递
-- 可选：实物货币
-- SQLite（默认）/ MySQL（可选，支持写入 XConomy 记录）
-
-## 命令
-
-玩家：
-```bash
-/svm
-/svm menu
-
-/svm money
-/svm balance
-
+/svm              # 打开市场 GUI
+/svm money        # 查询余额
 /svm pay <玩家> <金额>
-
-/svm sell <价格>
-/svm restock <数量>
-/svm pull
-
-/svm list
-/svm search <关键词>
-
-/svm buy <数量> <物品> [卖家]
-
-/svm cash <金额>
-/svm exchange <金额>
-
-/svm order <价格> <数量>
-/svm supply <数量>
 ```
-
-管理员：
-```bash
-/svm admin balance <玩家>
-/svm admin set <玩家> <金额>
-/svm admin add <玩家> <金额>
-/svm admin remove <玩家> <金额>
-
-/svm admin price <价格> [限购]
-/svm admin pull
-/svm admin purchase <价格> [限额]
-
-/svm admin cash get
-/svm admin cash del
-/svm admin cash list [物品]
-/svm admin cash <面值>
-
-/svm admin rank
-/svm admin reload
-```
-
-## 源码结构
-
-```
-src/
-  common/          # 所有版本共享的业务逻辑
-  versions/
-    v1_20_4/       # 1.20 – 1.20.4 专用代码（NBT ItemKey、GUI 等）
-    v1_20_6/       # 1.20.5 – 1.21.8 专用代码（ItemKey、GUI 等）
-    v1_21_11/      # 1.21.9+ 专用代码（Placeholder API、现代 ItemKey 等）
-```
-
-## Placeholder API
-
-仅 **1.21.9+** JAR 内置 Placeholder API，并提供：
-- `%server-market:balance%`
-- `%server-market:balance_short%`
-- `%server-market:parcel_count%`
-- `%server-market:player_name%`
-- `%server-market:top_name:<rank>%`（名次 1-10）
-- `%server-market:top_balance:<rank>%`（名次 1-10）
-- `%server-market:top_balance_short:<rank>%`（名次 1-10）
-
-## 联动 API
-
-### ServerMarketApi
-
-入口：`asagiribeta.serverMarket.api.ServerMarketApiProvider`
-
-- `getBalance`, `hasEnough`, `getParcelCount`
-- `addBalance`, `withdraw`, `setBalance`, `transfer`
-- `getTopBalances`, `getHistory`, `format`
-- `openMenu`, `getModVersion`
-
-### EconomyProvider（Vault 风格）
-
-入口：`asagiribeta.serverMarket.api.economy.EconomyProviderRegistry`
-
-其他模组可通过 `EconomyProviderRegistry.get()` 获取统一经济接口，支持余额查询、存取款、转账与格式化。
-
-### 事件
-
-- `ServerMarketEvents.BALANCE_CHANGED` — 任意余额变动后触发
-- `ServerMarketEvents.PRE_PURCHASE` — 购买前拦截（返回 false 取消）
-- `ServerMarketEvents.POST_PURCHASE` — 购买完成后通知
-
-### 经济特性
-
-- **市场税**：配置 `enable_tax` / `market_tax_rate`，卖家结算时自动扣税
-- **交易历史**：`enable_transaction_history` + `max_history_records` 自动修剪
-- **离线转账**：`/svm pay` 支持离线玩家（基于余额表 lookup）
-- **历史查询**：`/svm history [页码]`、`/svm admin history <玩家> [页码]`
-
-## 配置 / 数据库
-
-配置文件：`config/server-market/config.properties`
-
-SQLite 开箱即用；MySQL 请设置 `storage_type = mysql` 并填写 `mysql_*`。
-
-## CI / 发布
-
-GitHub Actions 仅在推送到 **master** 分支时运行 `./gradlew buildAll` 并发布 Release 附件。
 
 ## 许可证
 
-参见 [LICENSE.txt](./LICENSE.txt)
+参见 [LICENSE.txt](./LICENSE.txt)。

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -1,0 +1,105 @@
+# Commands
+
+All commands are under `/svm`. Most player commands require the player to be online and holding relevant items where noted.
+
+Permission nodes follow the pattern `servermarket.command.<subcommand>` for players and `servermarket.admin.<subcommand>` for admins (requires OP level 4 by default).
+
+---
+
+## Player commands
+
+| Command | Description |
+|---------|-------------|
+| `/svm` | Open the market GUI (alias of `/svm menu`) |
+| `/svm menu` | Open the market GUI |
+| `/svm money` | Show your balance |
+| `/svm balance` | Alias of `/svm money` |
+| `/svm pay <player> <amount>` | Transfer money (supports offline players who have joined before) |
+| `/svm history [page]` | View your transaction history (10 entries per page) |
+
+### Player shop
+
+Hold the item in your main hand unless noted.
+
+| Command | Description |
+|---------|-------------|
+| `/svm sell <price>` | List held item at `<price>` (first listing) |
+| `/svm restock <quantity>` | Add stock to an already-listed item |
+| `/svm pull` | Remove held item from your shop |
+| `/svm list` | List items on the market |
+| `/svm search <keyword>` | Search market listings |
+| `/svm buy <quantity> <item> [seller]` | Buy from market (`<item>` is an item ID, e.g. `minecraft:diamond`) |
+
+> When multiple NBT variants of the same item exist, use the GUI to pick the exact variant; `/svm buy` will not guess.
+
+### Physical currency
+
+| Command | Description |
+|---------|-------------|
+| `/svm cash <value> <quantity>` | Exchange balance for physical currency items (item must be configured by admin) |
+| `/svm exchange <amount>` | Convert held physical currency back to balance |
+
+### Buy orders (player)
+
+Hold the item you want to buy.
+
+| Command | Description |
+|---------|-------------|
+| `/svm order <price> <amount>` | Create/update a buy order (alias of purchase args) |
+| `/svm purchase <price> <amount>` | Create/update a buy order |
+| `/svm supply selltopurchase <quantity>` | Sell held items to matching buy orders |
+
+---
+
+## Admin commands
+
+Base: `/svm admin` (requires `servermarket.admin`, OP 4)
+
+### Balance management
+
+| Command | Description |
+|---------|-------------|
+| `/svm admin balance <player>` | Query balance (offline OK) |
+| `/svm admin set <player> <amount>` | Set balance |
+| `/svm admin add <player> <amount>` | Add balance |
+| `/svm admin remove <player> <amount>` | Deduct balance (offline OK; fails if insufficient) |
+| `/svm admin rank` | Show balance leaderboard |
+| `/svm admin history <player> [page]` | View a player's transaction history |
+
+### System shop
+
+Hold the item in your main hand.
+
+| Command | Description |
+|---------|-------------|
+| `/svm admin price <price> [limitPerDay]` | Set system shop price (`limitPerDay`: -1 = unlimited) |
+| `/svm admin pull` | Remove held item from system shop |
+| `/svm admin purchase <price> [limitPerDay]` | Set system buy order |
+
+### Physical currency (admin)
+
+| Command | Description |
+|---------|-------------|
+| `/svm admin cash <value>` | Register held item as physical currency with face value |
+| `/svm admin cash get` | Show face value of held item |
+| `/svm admin cash del` | Remove physical currency setting for held item |
+| `/svm admin cash list [item]` | List all physical currency configs |
+
+### Server
+
+| Command | Description |
+|---------|-------------|
+| `/svm admin lang <zh\|en>` | Switch server-side message language |
+| `/svm admin reload` | Reload `config.properties` |
+
+---
+
+## GUI
+
+The market GUI (`/svm` or `/svm menu`) provides:
+
+- Browse system and player shops
+- Purchase with exact NBT variant selection
+- My shop management, parcel station, balance rank
+
+Most operations available via commands can also be done through the GUI.

--- a/docs/Dev.md
+++ b/docs/Dev.md
@@ -1,0 +1,136 @@
+# Development
+
+## Prerequisites
+
+- **JDK 21** (Gradle toolchain; older MC groups may compile with `--release 17` bytecode)
+- Git
+
+Use the Gradle wrapper: `./gradlew`
+
+## Build
+
+```bash
+# Build all version groups (6 JARs)
+./gradlew buildAll
+
+# Build a single group
+./gradlew build -Pmc_group=1_21_11
+```
+
+Output: `build/libs/Server-market_<group>-<version>.jar`
+
+Version groups are defined in `gradle.properties` (`version_groups`, `group.*`).
+
+| Group key | MC range | Overlay |
+|-----------|----------|---------|
+| `1_20_4` | 1.20 – 1.20.4 | `v1_20_4` |
+| `1_20_6` | 1.20.5 – 1.20.6 | `v1_20_6` |
+| `1_21_1` | 1.21 – 1.21.1 | `v1_20_6` |
+| `1_21_5` | 1.21.2 – 1.21.5 | `v1_20_6` |
+| `1_21_8` | 1.21.6 – 1.21.8 | `v1_20_6` |
+| `1_21_11` | 1.21.9 – 1.21.11 | `v1_21_11` |
+
+There is no separate linter; `:compileKotlin` during `build` is the main static check.
+
+> Warning `(3.45.1.0) is not valid semver for dependency org.xerial:sqlite-jdbc` during `:processIncludeJars` is benign.
+
+## Source layout
+
+```
+src/
+  common/                 # Shared Kotlin + resources (business logic, commands, API)
+  versions/
+    v1_20_4/              # MC 1.20 – 1.20.4 (NBT ItemKey, GUI, Java 17 bytecode)
+    v1_20_6/              # MC 1.20.5 – 1.21.8 (ItemKey, GUI helpers)
+    v1_21_11/             # MC 1.21.9+ (modern ItemKey, Placeholder API)
+```
+
+Gradle merges `src/common` with the overlay for the selected `-Pmc_group`.
+
+## Local dev server
+
+```bash
+./gradlew runServer                      # defaults to 1_21_11
+./gradlew runServer -Pmc_group=1_21_8    # pick another group
+```
+
+First run:
+
+1. Set `eula=true` in `run/eula.txt`
+2. For offline testing, set in `run/server.properties`:
+   - `online-mode=false`
+   - `enforce-secure-profile=false`
+
+Console commands omit the leading `/`, e.g. `svm admin remove Player123 50`.
+
+Storage defaults to SQLite at `run/market.db`.
+
+## Local dev client (optional)
+
+```bash
+DISPLAY=:1 ./gradlew runClient -Pmc_group=1_21_11
+```
+
+## CI / releases
+
+GitHub Actions workflow `.github/workflows/build-release.yml`:
+
+- Runs `./gradlew buildAll` on pushes to `master`
+- Skipped when **only** Markdown files change (see `paths-ignore` in the workflow)
+- Publishes JARs to GitHub Releases
+
+Manual trigger: **Actions → Build and Release → Run workflow**.
+
+## Inter-mod API
+
+### ServerMarketApi
+
+Entry: `asagiribeta.serverMarket.api.ServerMarketApiProvider`
+
+```kotlin
+val api = ServerMarketApiProvider.get() ?: return
+api.getBalance(uuid)
+api.hasEnough(uuid, amount)
+api.transfer(from, to, amount, reason = "my-mod")
+api.getHistory(uuid, page = 1)
+api.format(1234.5)
+api.openMenu(player)
+```
+
+Methods: `getBalance`, `hasEnough`, `getParcelCount`, `addBalance`, `withdraw`, `setBalance`, `transfer`, `getTopBalances`, `getHistory`, `format`, `openMenu`, `getModVersion`.
+
+### EconomyProvider (Vault-style)
+
+Entry: `asagiribeta.serverMarket.api.economy.EconomyProviderRegistry`
+
+```kotlin
+val eco = EconomyProviderRegistry.get() ?: return
+eco.withdraw(uuid, 100.0, "shop_rent")
+eco.format(500.0)
+```
+
+### Events
+
+```kotlin
+// Fired after any balance change (commands, market, API)
+ServerMarketEvents.BALANCE_CHANGED.register { uuid, delta, reason, actor -> ... }
+
+// Return false to cancel a market purchase
+ServerMarketEvents.PRE_PURCHASE.register { buyer, itemId, nbt, qty, cost -> qty <= 64 }
+
+// Fired after purchase attempt (success or failure)
+ServerMarketEvents.POST_PURCHASE.register { buyer, itemId, qty, cost, success -> ... }
+```
+
+## Architecture notes
+
+- **EconomyService** — single entry point for balance mutations, history, and events
+- **Database** — single-thread executor; use `database.supplyAsync { }` for async DB work
+- **MarketService** — purchase/sell logic; applies market tax when configured
+- **PlayerLookupService** — offline player name ↔ UUID resolution via balance table
+
+## Related files
+
+- `gradle.properties` — mod version, version groups, dependency pins
+- `build.gradle.kts` — multi-version overlay build logic
+- `AGENTS.md` — Cursor Cloud agent instructions (not user-facing wiki)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,0 +1,114 @@
+# Installation
+
+## Requirements
+
+- **Minecraft server**: 1.20 – 1.21.11 (Fabric)
+- **Fabric Loader** and **Fabric API** (version matched to your MC version)
+- **Fabric Language Kotlin**
+- **Fabric Permissions API** (required at runtime)
+
+### Optional
+
+| Component | Purpose |
+|-----------|---------|
+| [LuckPerms](https://luckperms.net/) | Permission management (recommended) |
+| MySQL + XConomy tables | Shared economy storage across plugins |
+| Placeholder API | Placeholders (built into the 1.21.9+ JAR only) |
+
+## Download
+
+1. Open [Releases](https://github.com/AsagiriBeta/Server-market/releases).
+2. Download the JAR whose suffix matches your Minecraft version:
+
+| JAR suffix | Minecraft range |
+|------------|-----------------|
+| `Server-market_1_20_4-*.jar` | 1.20 – 1.20.4 |
+| `Server-market_1_20_6-*.jar` | 1.20.5 – 1.20.6 |
+| `Server-market_1_21_1-*.jar` | 1.21 – 1.21.1 |
+| `Server-market_1_21_5-*.jar` | 1.21.2 – 1.21.5 |
+| `Server-market_1_21_8-*.jar` | 1.21.6 – 1.21.8 |
+| `Server-market_1_21_11-*.jar` | 1.21.9 – 1.21.11 |
+
+3. Place the JAR in your server's `mods/` folder alongside Fabric API, Kotlin, and Permissions API.
+4. Start the server once to generate the config file.
+
+## Configuration
+
+Config path: `config/server-market/config.properties`
+
+Reload in-game: `/svm admin reload`
+
+### Economy
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `initial_player_balance` | `100.0` | Balance for first-time joiners |
+| `max_transfer_amount` | `1000000.0` | Max amount per `/svm pay` |
+| `enable_transaction_history` | `true` | Record transactions in the `history` table |
+| `max_history_records` | `10000` | Auto-prune oldest records beyond this limit |
+| `enable_tax` | `false` | Deduct tax from player shop sales |
+| `market_tax_rate` | `0.05` | Tax rate (0.0–1.0) when `enable_tax=true` |
+
+### Storage (SQLite — default)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `storage_type` | `sqlite` | `sqlite` or `mysql` |
+| `sqlite_path` | `market.db` | SQLite database file path |
+
+SQLite works out of the box; no extra setup required.
+
+### Storage (MySQL / XConomy)
+
+Set `storage_type=mysql` and configure:
+
+| Key | Default |
+|-----|---------|
+| `mysql_host` | `localhost` |
+| `mysql_port` | `3306` |
+| `mysql_database` | `server_market` |
+| `mysql_user` | `root` |
+| `mysql_password` | *(empty)* |
+| `mysql_use_ssl` | `false` |
+| `mysql_jdbc_params` | *(empty)* |
+
+XConomy table names (when sharing an existing XConomy database):
+
+| Key | Default |
+|-----|---------|
+| `xconomy_player_table` | `xconomy` |
+| `xconomy_non_player_table` | `xconomynon` |
+| `xconomy_record_table` | `xconomyrecord` |
+| `xconomy_login_table` | `xconomylogin` |
+| `xconomy_system_account` | `SERVER` |
+| `xconomy_write_record` | `false` |
+
+Set `xconomy_write_record=true` to mirror transactions into XConomy's record table (MySQL only).
+
+### Debug
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enable_debug_logging` | `false` | Verbose debug logs |
+
+## Permissions
+
+The mod uses [Fabric Permissions API](https://github.com/lucko/fabric-permissions-api). With LuckPerms, grant nodes such as:
+
+- `servermarket.command` — base access to `/svm`
+- `servermarket.command.pay` — use `/svm pay`
+- `servermarket.admin` — all admin subcommands
+
+See command-specific nodes in [Commands](./Commands.md).
+
+## Placeholder API (1.21.9+ JAR only)
+
+Available placeholders when Placeholder API is installed:
+
+- `%server-market:balance%`
+- `%server-market:balance_short%`
+- `%server-market:parcel_count%`
+- `%server-market:player_name%`
+- `%server-market:top_name:<rank>%` (rank 1–10)
+- `%server-market:top_balance:<rank>%`
+- `%server-market:top_balance_short:<rank>%`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to merged PR #11. Prepares documentation for GitHub Wiki migration.

### Changes

- **README.md / README_ZH.md** — simplified to brief Home-page content with links to detailed docs
- **docs/Installation.md** — dependencies, JAR selection, configuration reference
- **docs/Commands.md** — full `/svm` command reference
- **docs/Dev.md** — build instructions, source layout, local dev, inter-mod API
- **CI** — skip Build and Release on `master` pushes that only change Markdown files (`paths-ignore`)

## Test plan

- [x] Docs-only change; no code changes
- [ ] After merge, verify a docs-only push to `master` does not trigger GitHub Actions
- [ ] Copy `docs/*.md` to GitHub Wiki pages as needed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fcc77b4-8f21-40fb-9dad-143dc7890c60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fcc77b4-8f21-40fb-9dad-143dc7890c60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

